### PR TITLE
fix: исправить ошибки после ревью

### DIFF
--- a/src/components/addCard.js
+++ b/src/components/addCard.js
@@ -7,6 +7,7 @@ import {
   inputLinkImage,
   submitFormAddCard,
   cardsContainer,
+  settingsValidation as settings,
 } from './variables';
 
 import { openPopup, closePopup } from './modal';
@@ -18,10 +19,9 @@ import { hideAllInputError, options } from './validate';
  */
 function openFormAddCard() {
   submitFormAddCard.disabled = true;
-  hideAllInputError(formAddCard, options);
+  hideAllInputError(formAddCard, settings);
   formAddCard.reset();
   openPopup(popupAddCard);
-  formAddCard.addEventListener('submit', handleFormAddCard);
 }
 
 /**
@@ -36,7 +36,6 @@ function handleFormAddCard(evt) {
   };
   cardsContainer.prepend(createCard(newCard));
   closePopup(popupAddCard);
-  formAddCard.removeEventListener('submit', handleFormAddCard);
 }
 
-export { openFormAddCard };
+export { openFormAddCard, handleFormAddCard };

--- a/src/components/editProfile.js
+++ b/src/components/editProfile.js
@@ -7,20 +7,20 @@ import {
   inputAbout,
   username,
   about,
+  settingsValidation as settings,
 } from './variables';
 
 import { openPopup, closePopup } from './modal';
-import { hideAllInputError, options } from './validate';
+import { hideAllInputError } from './validate';
 
 /**
  * Функция открытия popup c формой редактирования профиля
  */
 function openFormEditProfile() {
-  hideAllInputError(formEditProfile, options);
+  hideAllInputError(formEditProfile, settings);
   inputUsername.value = username.textContent;
   inputAbout.value = about.textContent;
   openPopup(popupEditProlile);
-  formEditProfile.addEventListener('submit', handleFormEditProfile);
 }
 
 /**
@@ -32,7 +32,6 @@ function handleFormEditProfile(evt) {
   username.textContent = inputUsername.value;
   about.textContent = inputAbout.value;
   closePopup(popupEditProlile);
-  formEditProfile.removeEventListener('submit', handleFormEditProfile);
 }
 
-export { openFormEditProfile };
+export { openFormEditProfile, handleFormEditProfile };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,16 +5,22 @@ import {
   popupList,
   btnEdit,
   btnAdd,
+  formEditProfile,
+  formAddCard,
+  settingsValidation
 } from './variables';
 import { initialCards } from './initialCards';
 import { renderInitialCards } from './card';
 import { enableValidation } from './validate';
 import { closePopup } from './modal';
-import { openFormEditProfile } from './editProfile';
-import { openFormAddCard } from './addCard';
+import { openFormEditProfile, handleFormEditProfile } from './editProfile';
+import { openFormAddCard, handleFormAddCard } from './addCard';
 
 btnEdit.addEventListener('click', openFormEditProfile);
 btnAdd.addEventListener('click', openFormAddCard);
+
+formEditProfile.addEventListener('submit', handleFormEditProfile);
+formAddCard.addEventListener('submit', handleFormAddCard);
 
 popupList.forEach(popup => popup.addEventListener('mousedown', evt => {
   if (evt.target.classList.contains('popup') || evt.target.classList.contains('popup__btn_type_close')) {
@@ -22,13 +28,6 @@ popupList.forEach(popup => popup.addEventListener('mousedown', evt => {
   }
 }));
 
-enableValidation({
-  formSelector: '.popup__form',
-  inputSelector: '.popup__input',
-  submitButtonSelector: '.popup__btn_type_submit',
-  inputErrorClass: 'popup__input_error',
-  errorClass: 'popup__error-message_visible'
-});
+enableValidation(settingsValidation);
 
 renderInitialCards(initialCards);
-

--- a/src/components/validate.js
+++ b/src/components/validate.js
@@ -1,25 +1,17 @@
 'use strict';
 
-const options = {
-  formSelector: '',
-  inputSelector: '',
-  submitButtonSelector: '',
-  inputErrorClass: '',
-  errorClass: ''
-};
-
 /**
  * Функция показа сообщения об ошибки
  * @param {object} formElement - DOM-элемент формы 
  * @param {object} inputElement - DOM-элемент поля ввода
  * @param {string} errorMessage - текст сообщения ошибки
  */
-function showInputError(formElement, inputElement, errorMessage) {
+function showInputError(formElement, inputElement, errorMessage, settings) {
   const errorElement = formElement.querySelector(`.${inputElement.id}-error`);
 
-  inputElement.classList.add(options.inputErrorClass);
+  inputElement.classList.add(settings.inputErrorClass);
   errorElement.textContent = errorMessage;
-  errorElement.classList.add(options.errorClass);
+  errorElement.classList.add(settings.errorClass);
 }
 
 /**
@@ -27,23 +19,23 @@ function showInputError(formElement, inputElement, errorMessage) {
  * @param {object} formElement - DOM-элемент формы 
  * @param {object} inputElement - DOM-элемент поля ввода
  */
-function hideInputError(formElement, inputElement) {
+function hideInputError(formElement, inputElement, settings) {
   const errorElement = formElement.querySelector(`.${inputElement.id}-error`);
 
-  inputElement.classList.remove(options.inputErrorClass);
+  inputElement.classList.remove(settings.inputErrorClass);
   errorElement.textContent = '';
-  errorElement.classList.remove(options.errorClass);
+  errorElement.classList.remove(settings.errorClass);
 }
 
 /**
  * Функция скытия сообщения всех ошибкок
  * @param {object} formElement - DOM-элемент формы 
  */
-function hideAllInputError(formElement, options) {
-  const inputList = Array.from(formElement.querySelectorAll(options.inputSelector));
+function hideAllInputError(formElement, settings) {
+  const inputList = Array.from(formElement.querySelectorAll(settings.inputSelector));
 
   inputList.forEach(inputElement => {
-    hideInputError(formElement, inputElement);
+    hideInputError(formElement, inputElement, settings);
   });
 }
 
@@ -52,7 +44,7 @@ function hideAllInputError(formElement, options) {
  * @param {object} formElement - DOM-элемент формы 
  * @param {object} inputElement - DOM-элемент поля ввода
  */
-function isValid(formElement, inputElement) {
+function isValid(formElement, inputElement, settings) {
   if (inputElement.validity.patternMismatch) {
     inputElement.setCustomValidity(inputElement.dataset.errorMessage);
   } else {
@@ -60,9 +52,9 @@ function isValid(formElement, inputElement) {
   }
 
   if (!inputElement.validity.valid) {
-    showInputError(formElement, inputElement, inputElement.validationMessage);
+    showInputError(formElement, inputElement, inputElement.validationMessage, settings);
   } else {
-    hideInputError(formElement, inputElement);
+    hideInputError(formElement, inputElement, settings);
   }
 }
 
@@ -95,13 +87,13 @@ function toggleButtonState(inputList, buttonElement) {
  * Функция установки слушателей на форму
  * @param {object} formElement - DOM-элемент формы
  */
-function setEventListeners(formElement) {
-  const inputList = Array.from(formElement.querySelectorAll(options.inputSelector));
-  const btnElement = formElement.querySelector(options.submitButtonSelector);
+function setEventListeners(formElement, settings) {
+  const inputList = Array.from(formElement.querySelectorAll(settings.inputSelector));
+  const btnElement = formElement.querySelector(settings.submitButtonSelector);
 
   inputList.forEach(inputElement => {
     inputElement.addEventListener('input', () => {
-      isValid(formElement, inputElement);
+      isValid(formElement, inputElement, settings);
       toggleButtonState(inputList, btnElement);
     });
   });
@@ -111,15 +103,11 @@ function setEventListeners(formElement) {
  * Функция ключения валидации форм на странице
  * @param {object} opts - объект с настройками 
  */
-function enableValidation(opts) {
-  for (let key in opts) {
-    options[key] = opts[key];
-  }
-
-  const formList = Array.from(document.querySelectorAll(options.formSelector));
+function enableValidation(settings) {
+  const formList = Array.from(document.querySelectorAll(settings.formSelector));
   formList.forEach(formElement => {
-    setEventListeners(formElement);
+    setEventListeners(formElement, settings);
   });
 }
 
-export { enableValidation, hideAllInputError, options };
+export { enableValidation, hideAllInputError};

--- a/src/components/variables.js
+++ b/src/components/variables.js
@@ -1,5 +1,14 @@
 'use strict';
 
+/*Настройки для валидации форм*/
+export const settingsValidation = {
+  formSelector: '.popup__form',
+  inputSelector: '.popup__input',
+  submitButtonSelector: '.popup__btn_type_submit',
+  inputErrorClass: 'popup__input_error',
+  errorClass: 'popup__error-message_visible'
+} 
+
 /*Элементы необхомые для создания и добавления карточки */
 export const cardsContainer = document.querySelector('.cards__list');
 export const cardTemplate = document.querySelector('#card-template').content;


### PR DESCRIPTION
- [x] Обработчик сабмита нужно только 1 раз установить на форму

- [x] Все строки-селекторы для валидации нужно брать только из объекта валидации, который передается в вызов каждой функции, начиная с enableValidation(settings), далее передается в setEventListeners(formElement, settings) и так далее. Это делается для того, чтобы можно было одним движением изменить селекторы в одном месте, а не искать их по всему коду, изменяя каждую строку-селектор.